### PR TITLE
Stop install script from deleting existing data folder

### DIFF
--- a/vscode.portable/tools/ChocolateyInstall.ps1
+++ b/vscode.portable/tools/ChocolateyInstall.ps1
@@ -9,7 +9,7 @@ $ChecksumType64 = 'sha256'
 $Checksum64 = '5081d8d41a0786587b6a8c28f59bca163b09d5fa5dc42bb9d9681d6199bdf4f1'
 $InstallationPath = Join-Path $(Get-ToolsLocation) 'vscode'
 
-Remove-Item $InstallationPath -Recurse -Force -ErrorAction Ignore
+Get-ChildItem -Path $InstallationPath -Exclude data | Remove-Item -Recurse -Force -ErrorAction Ignore
 New-Item -ItemType Directory -Path $InstallationPath -Force -ErrorAction Ignore
 
 $PackageArgs = @{


### PR DESCRIPTION
Prevents the install/update of the package from deleting the "data" folder where all the user settings and extensions are. Closes issue #2.