### PR TITLE
[vscode.portable] Ensure install.ps1 downloads the correct version

### DIFF
--- a/vscode.portable/tools/ChocolateyInstall.ps1
+++ b/vscode.portable/tools/ChocolateyInstall.ps1
@@ -1,10 +1,11 @@
 ﻿$ErrorActionPreference = 'Stop'
 
 $PackageName = 'vscode'
-$Url32 = 'https://vscode-update.azurewebsites.net/latest/win32-archive/stable'
+$Version = '1.39.0'
+$Url32 = 'https://vscode-update.azurewebsites.net/' + $Version + '/win32-archive/stable'
 $ChecksumType32 = 'sha256'
 $Checksum32 = 'a6d4fa21f0fa362daf9021edaad3adbb67a760ba4de8e0b6ee7938144f6d4440'
-$Url64 = 'https://vscode-update.azurewebsites.net/latest/win32-x64-archive/stable'
+$Url64 = 'https://vscode-update.azurewebsites.net/' + $Version + '/win32-x64-archive/stable'
 $ChecksumType64 = 'sha256'
 $Checksum64 = '899300204bf86ae4817050efbd21c495e769f2069d1aca0062eca931230562ee'
 $InstallationPath = Join-Path $(Get-ToolsLocation) $PackageName

--- a/vscode.portable/update.ps1
+++ b/vscode.portable/update.ps1
@@ -7,6 +7,7 @@ function global:au_SearchReplace {
             "(^[$]ChecksumType32\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType32)'"
             "(^[$]Checksum64\s*=\s*)('.*')"     = "`$1'$($Latest.Checksum64)'"
             "(^[$]ChecksumType64\s*=\s*)('.*')" = "`$1'$($Latest.ChecksumType64)'"
+            "(^[$]Version\s*=\s*)('.*')"        = "`$1'$($Latest.Version)'"
         }
     }
 }


### PR DESCRIPTION
Make sure that chocolatey downloads the correct version to match the Checksum hashes and not always the latest version.

Currently it always downloads the latest version. For example now when one tries to update the package it downloads the version 1.39.1 (that just released) but the checksum hashes were created for the version 1.39.0 and stops the update.

This pull request makes it so it downloads the version for to match the checksum.
