### PR TITLE
[vscode.portable] Change BinFile to 'bin\code.cmd' to allow for cmdline arguments

### DIFF
--- a/vscode.portable/tools/ChocolateyInstall.ps1
+++ b/vscode.portable/tools/ChocolateyInstall.ps1
@@ -25,7 +25,7 @@ $PackageArgs = @{
 }
 Install-ChocolateyZipPackage @PackageArgs
 
-$BinPath = Join-Path $InstallationPath "Code.exe"
+$BinPath = Join-Path $InstallationPath "bin\code.cmd"
 Install-BinFile -Name Code -Path $BinPath
 $LinkPath = Join-Path $([Environment]::GetFolderPath("CommonDesktopDirectory")) "Visual Studio Code.lnk"
 Install-ChocolateyShortcut -ShortcutFilePath $LinkPath -TargetPath $BinPath -WorkingDirectory $InstallationPath


### PR DESCRIPTION
Change BinFile to 'bin\code.cmd' to allow for cmdline arguments like --wait or --list-extensions.

From my personal testing I didn't find any setback in using 'code.cmd' instead of 'Code.exe'. But it might require further testing.

I have made this change because some users were requesting it on the Chocolatey website page for the vscode.portable package.